### PR TITLE
Improve testing, fix some bugs

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,4 @@
+---
 fixtures:
-  repositories:
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
   symlinks:
-    "etcd": "#{source_dir}"
-
+    etcd: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ metadata.json
 Gemfile.lock
 .rspec_system/
 .*.sw*
-spec/fixtures/
+spec/fixtures/modules/
+spec/fixtures/manifests/
 .project
 .bundle/
 .librarian/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ Gemfile.lock
 spec/fixtures/
 .project
 .bundle/
+.librarian/
+.tmp/
+Puppetfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ group :test do
   gem "puppet-lint"
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem "puppet-syntax"
+  gem 'librarian-puppet', '~> 1.0.0'
   gem "puppetlabs_spec_helper"
 end
 

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+forge 'http://forge.puppetlabs.com'
+
+mod 'puppetlabs/stdlib', '>=3.2.0'

--- a/Rakefile
+++ b/Rakefile
@@ -27,6 +27,13 @@ exclude_paths = [
 PuppetLint.configuration.ignore_paths = exclude_paths
 PuppetSyntax.exclude_paths = exclude_paths
 
+# use librarian-puppet to manage fixtures instead of .fixtures.yml
+# offers more possibilities like explicit version management, forge downloads,...
+task :librarian_spec_prep do
+ sh "librarian-puppet install --path=spec/fixtures/modules/"
+end
+task :spec_prep => :librarian_spec_prep
+
 desc "Run acceptance tests"
 RSpec::Core::RakeTask.new(:acceptance) do |t|
   t.pattern = 'spec/acceptance'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -21,8 +21,8 @@ class etcd::config {
 
       file { '/etc/etcd/etcd.conf':
         ensure  => file,
-        owner   => 'root',
-        group   => 'root',
+        owner   => $etcd::user,
+        group   => $etcd::group,
         mode    => '0644',
         content => template('etcd/etcd.conf.erb'),
         require => File['/etc/etcd']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,11 +51,20 @@ class etcd (
   $peer_ca_file            = $etcd::params::etcd_peer_ca_file,
   $peer_cert_File          = $etcd::params::etcd_peer_cert_File,
   $peer_key_file           = $etcd::params::etcd_peer_key_file) inherits etcd::params {
-  validate_array($cors)
 
+  # Discovery settings
+  validate_bool($discovery)
+  # If not using discovery, should have a valid list of peers
   if (!$discovery) {
     validate_array($peers)
   }
+  # If using discovery, should have a valid discovery token
+  if ($discovery and $discovery_token == '') {
+    fail('Invalid discovery token specified')
+  }
+
+  # Validate other params
+  validate_array($cors)
   validate_bool($manage_user)
   validate_bool($snapshot)
   validate_bool($verbose)

--- a/spec/classes/coverage_spec.rb
+++ b/spec/classes/coverage_spec.rb
@@ -1,0 +1,1 @@
+at_exit { RSpec::Puppet::Coverage.report! }

--- a/spec/classes/etcd_spec.rb
+++ b/spec/classes/etcd_spec.rb
@@ -17,6 +17,11 @@ describe 'etcd', :type => :class do
       let(:etcd_default_config) {
         File.read(my_fixture("etcd.conf"))
       }
+      
+      # Default upstart file
+      let(:etcd_default_upstart) {
+        File.read(my_fixture("etcd.upstart"))
+      }
 
       # etcd::init resources
       it { should create_class('etcd') }
@@ -56,7 +61,7 @@ describe 'etcd', :type => :class do
           'owner'  => 'etcd',
           'group'  => 'etcd',
           'mode'   => '0444'
-        }).that_notifies('Service[etcd]') }
+        }).with_content(etcd_default_upstart).that_notifies('Service[etcd]') }
       it { should contain_service('etcd').with_ensure('running').with_enable('true').with_provider('upstart') }
     end
 

--- a/spec/classes/etcd_spec.rb
+++ b/spec/classes/etcd_spec.rb
@@ -7,9 +7,17 @@ describe 'etcd', :type => :class do
   end
 
   describe 'On a Debian OS' do
-    let(:facts) { {:osfamily => 'Debian'} }
+    let(:facts) { {
+        :osfamily => 'Debian',
+        :fqdn     => 'etcd.test.local'
+      } }
 
     context 'With defaults' do
+      # Default etcd conf file
+      let(:etcd_default_config) {
+        File.read(my_fixture("etcd.conf"))
+      }
+
       # etcd::init resources
       it { should create_class('etcd') }
       it { should contain_class('etcd::params') }
@@ -40,7 +48,7 @@ describe 'etcd', :type => :class do
           'owner'  => 'etcd',
           'group'  => 'etcd',
           'mode'   => '0644'
-        }).that_requires('File[/etc/etcd]') }
+        }).with_content(etcd_default_config).that_requires('File[/etc/etcd]') }
       # etcd::service resources
       it { should contain_file('etcd-servicefile').with({
           'ensure' => 'file',
@@ -108,7 +116,7 @@ describe 'etcd', :type => :class do
         should contain_file('/etc/etcd/etcd.conf').with_content(/discovery\s*= "http:\/\/local-discovery:4001\/v2\/keys\/123456"/)
       }
     end
-    
+
     context 'When enabling cluster discovery without a token' do
       let(:params) { { :discovery => true } }
       it {
@@ -181,9 +189,17 @@ describe 'etcd', :type => :class do
   end
 
   describe 'On a Redhat OS' do
-    let(:facts) { {:osfamily => 'Redhat'} }
+    let(:facts) { {
+        :osfamily => 'Redhat',
+        :fqdn     => 'etcd.test.local'
+      } }
 
     context 'With defaults' do
+      # Default etcd sysconfig file
+      let(:etcd_default_sysconfig) {
+        File.read(my_fixture("etcd.sysconfig"))
+      }
+      
       # etcd::init resources
       it { should create_class('etcd') }
       it { should contain_class('etcd::params') }
@@ -208,7 +224,7 @@ describe 'etcd', :type => :class do
           'owner'  => 'etcd',
           'group'  => 'etcd',
           'mode'   => '0644'
-        }) }
+        }).with_content(etcd_default_sysconfig) }
       # etcd::service resources
       it { should contain_file('etcd-servicefile').with({
           'ensure' => 'file',
@@ -271,19 +287,19 @@ describe 'etcd', :type => :class do
         should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_DISCOVERY_TOKEN="123456"/)
       }
     end
-    
+
     context 'When enabling cluster discovery without a token' do
       let(:params) { { :discovery => true } }
       it {
         should raise_error()
       }
     end
-    
+
     context 'When enabling verbose logging' do
       let(:params) { { :verbose => true } }
       it { should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_LOGGING="v"/) }
     end
-    
+
     context 'When enabling very verbose logging' do
       let(:params) { { :very_verbose => true } }
       it { should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_LOGGING="vv"/) }

--- a/spec/classes/etcd_spec.rb
+++ b/spec/classes/etcd_spec.rb
@@ -1,55 +1,122 @@
 require 'spec_helper'
 
 describe 'etcd', :type => :class do
-  context 'On an unknown OS' do
+  describe 'On an unknown OS' do
     let(:facts) { {:osfamily => 'Unknown'} }
     it { should raise_error() }
   end
 
-  context 'On a Debian OS' do
+  describe 'On a Debian OS' do
+    let(:facts) { {:osfamily => 'Debian'} }
+
     context 'With defaults' do
-      let(:facts) { {:osfamily => 'Debian'} }
-      it { should contain_package('etcd')}
-      it { should create_class('etcd::install')}
-      it { should create_class('etcd::config')}
-      it { should create_class('etcd::service')}
-      it { should contain_user('etcd').with_ensure('present') }
-      it { should contain_service('etcd').with_ensure('running').with_enable('true') }
+      # etcd::init resources
+      it { should create_class('etcd') }
+      it { should contain_class('etcd::params') }
+      it { should contain_anchor('etcd::begin') }
+      it { should create_class('etcd::install').that_requires('Anchor[etcd::begin]')}
+      it { should create_class('etcd::config').that_requires('Class[etcd::install]').that_notifies('Class[etcd::service]')}
+      it { should create_class('etcd::service').that_comes_before('Anchor[etcd::end]')}
+      it { should contain_anchor('etcd::end') }
+      # etcd::install resources
+      it { should contain_group('etcd').with_ensure('present') }
+      it { should contain_user('etcd').with_ensure('present').with_gid('etcd').that_requires('Group[etcd]') }
+      it { should contain_file('/var/lib/etcd').with({
+          'ensure' =>'directory',
+          'owner'  => 'etcd',
+          'group'  => 'etcd',
+          'mode'   => '0750'
+        }).that_requires('User[etcd]').that_comes_before('Package[etcd]') }
+      it { should contain_package('etcd').with_ensure('installed')}
+      # etcd::config resources
+      it { should contain_file('/etc/etcd').with({
+          'ensure' => 'directory',
+          'owner'  => 'etcd',
+          'group'  => 'etcd',
+          'mode'   => '0555'
+        }) }
+      it { should contain_file('/etc/etcd/etcd.conf').with({
+          'ensure' => 'file',
+          'owner'  => 'etcd',
+          'group'  => 'etcd',
+          'mode'   => '0644'
+        }).that_requires('File[/etc/etcd]') }
+      # etcd::service resources
+      it { should contain_file('etcd-servicefile').with({
+          'ensure' => 'file',
+          'path'   => '/etc/init/etcd.conf',
+          'owner'  => 'etcd',
+          'group'  => 'etcd',
+          'mode'   => '0444'
+        }).that_notifies('Service[etcd]') }
+      it { should contain_service('etcd').with_ensure('running').with_enable('true').with_provider('upstart') }
     end
-  
+
     context 'When overriding service parameters' do
-      let(:facts) { {:osfamily => 'Debian'} }
-      let(:params) { {:service_ensure => 'stopped',
-          :service_enable => false }}
+      let(:params) { {
+          :service_ensure => 'stopped',
+          :service_enable => false
+        } }
       it { should contain_service('etcd').with_ensure('stopped').with_enable('false') }
     end
-  
+
     context 'When overriding package parameters' do
-      let(:facts) { {:osfamily => 'Debian'} }
-      let(:params) { {:package_ensure => 'absent',
+      let(:params) { {
+          :package_ensure => 'absent',
           :package_name   => 'custom_etcd' }}
       it { should contain_package('etcd').with(
         'name'   => 'custom_etcd',
         'ensure' => 'absent'
-        )
+        ) }
+    end
+
+    context 'When asked not to manage the user' do
+      let(:params) { {:manage_user => false } }
+      it {
+        should_not contain_group('etcd')
+        should_not contain_user('etcd')
       }
     end
-  
-    context 'When asked not to manage the user' do
-      let(:facts) { {:osfamily => 'Debian'} }
-      let(:params) { {:manage_user => false } }
-      it { should_not contain_user('etcd') }
-    end
-  
+
     context 'When using a custom data directory' do
-      let(:facts) { {:osfamily => 'Debian'} }
-      let(:params) { {:manage_data_dir => false,
-          :data_dir        => '/custom/dne/'  } }
-      it { should_not contain_file('/custom/dne') }
+      let(:params) { { :data_dir => '/custom/dne/' } }
+      it { should contain_file('/custom/dne/').with({
+          'ensure' =>'directory',
+          'owner'  => 'etcd',
+          'group'  => 'etcd',
+          'mode'   => '0750'
+        }).that_requires('User[etcd]').that_comes_before('Package[etcd]') }
     end
-  
+
+    context 'When enabling cluster discovery' do
+      let(:params) { {
+          :discovery       => true,
+          :discovery_token => '123456'
+        } }
+      it {
+        should contain_file('/etc/etcd/etcd.conf').with_content(/discovery\s*= "https:\/\/discovery.etcd.io\/123456"/)
+      }
+    end
+
+    context 'When specifying a custom discovery endpoint and token' do
+      let(:params) { {
+          :discovery          => true,
+          :discovery_endpoint => 'http://local-discovery:4001/v2/keys/',
+          :discovery_token    => '123456'
+        } }
+      it {
+        should contain_file('/etc/etcd/etcd.conf').with_content(/discovery\s*= "http:\/\/local-discovery:4001\/v2\/keys\/123456"/)
+      }
+    end
+    
+    context 'When enabling cluster discovery without a token' do
+      let(:params) { { :discovery => true } }
+      it {
+        should raise_error()
+      }
+    end
+
     context 'When specifying all of the etcd config params' do
-      let(:facts) { {:osfamily => 'Debian'} }
       let(:params) { {
           :addr                    => '1.2.3.4:5678',
           :bind_addr               => '9.9.9.9:9999',
@@ -76,6 +143,12 @@ describe 'etcd', :type => :class do
           :peer_cert_File          => '/test/peer_cert_file',
           :peer_key_file           => '/test/peer_key_file'
         } }
+      it { should contain_file('/test/data_dir').with({
+          'ensure' =>'directory',
+          'owner'  => 'etcd',
+          'group'  => 'etcd',
+          'mode'   => '0750'
+        }).that_requires('User[etcd]').that_comes_before('Package[etcd]') }
       it {
         # Ensure that the config file is correctly populated
         should contain_file('/etc/etcd/etcd.conf').with_content(/addr\s*= "1\.2\.3\.4:5678"/)
@@ -88,6 +161,7 @@ describe 'etcd', :type => :class do
         should contain_file('/etc/etcd/etcd.conf').with_content(/key_file\s*= "\/test\/key_file"/)
         should contain_file('/etc/etcd/etcd.conf').with_content(/peers\s*= \["peer1", "peer2"\]/)
         should contain_file('/etc/etcd/etcd.conf').with_content(/peers_file\s*= "\/test\/peers_file"/)
+        should contain_file('/etc/etcd/etcd.conf').without_content(/discovery\s*=/)
         should contain_file('/etc/etcd/etcd.conf').with_content(/max_result_buffer\s*= 222/)
         should contain_file('/etc/etcd/etcd.conf').with_content(/max_retry_attempts\s*= 333/)
         should contain_file('/etc/etcd/etcd.conf').with_content(/name\s*= "test_node_name"/)
@@ -102,6 +176,172 @@ describe 'etcd', :type => :class do
         should contain_file('/etc/etcd/etcd.conf').with_content(/key_file\s*= "\/test\/peer_key_file"/)
         should contain_file('/etc/etcd/etcd.conf').with_content(/election_timeout\s*= 400/)
         should contain_file('/etc/etcd/etcd.conf').with_content(/heartbeat_interval\s*= 60/)
+      }
+    end
+  end
+
+  describe 'On a Redhat OS' do
+    let(:facts) { {:osfamily => 'Redhat'} }
+
+    context 'With defaults' do
+      # etcd::init resources
+      it { should create_class('etcd') }
+      it { should contain_class('etcd::params') }
+      it { should contain_anchor('etcd::begin') }
+      it { should create_class('etcd::install').that_requires('Anchor[etcd::begin]')}
+      it { should create_class('etcd::config').that_requires('Class[etcd::install]').that_notifies('Class[etcd::service]')}
+      it { should create_class('etcd::service').that_comes_before('Anchor[etcd::end]')}
+      it { should contain_anchor('etcd::end') }
+      # etcd::install resources
+      it { should contain_group('etcd').with_ensure('present') }
+      it { should contain_user('etcd').with_ensure('present').with_gid('etcd').that_requires('Group[etcd]') }
+      it { should contain_file('/var/lib/etcd').with({
+          'ensure' =>'directory',
+          'owner'  => 'etcd',
+          'group'  => 'etcd',
+          'mode'   => '0750'
+        }).that_requires('User[etcd]').that_comes_before('Package[etcd]') }
+      it { should contain_package('etcd').with_ensure('installed')}
+      # etcd::config resources
+      it { should contain_file('/etc/sysconfig/etcd').with({
+          'ensure' => 'present',
+          'owner'  => 'etcd',
+          'group'  => 'etcd',
+          'mode'   => '0644'
+        }) }
+      # etcd::service resources
+      it { should contain_file('etcd-servicefile').with({
+          'ensure' => 'file',
+          'path'   => '/etc/init.d/etcd',
+          'owner'  => 'etcd',
+          'group'  => 'etcd',
+          'mode'   => '0755'
+        }).that_notifies('Service[etcd]') }
+      it { should contain_service('etcd').only_with( {
+          'ensure'   => 'running',
+          'enable'   => 'true',
+          'provider' => nil
+        } ) }
+    end
+
+    context 'When overriding service parameters' do
+      let(:params) { {
+          :service_ensure => 'stopped',
+          :service_enable => false }}
+      it { should contain_service('etcd').with_ensure('stopped').with_enable('false') }
+    end
+
+    context 'When overriding package parameters' do
+      let(:params) { {
+          :package_ensure => 'absent',
+          :package_name   => 'custom_etcd' }}
+      it { should contain_package('etcd').with(
+        'name'   => 'custom_etcd',
+        'ensure' => 'absent'
+        )
+      }
+    end
+
+    context 'When asked not to manage the user' do
+      let(:params) { {:manage_user => false } }
+      it {
+        should_not contain_group('etcd')
+        should_not contain_user('etcd')
+      }
+    end
+
+    context 'When using a custom data directory' do
+      let(:params) { { :data_dir => '/custom/dne/' } }
+      it { should contain_file('/custom/dne/').with({
+          'ensure' => 'directory',
+          'owner'  => 'etcd',
+          'group'  => 'etcd',
+          'mode'   => '0750'
+        }).that_requires('User[etcd]').that_comes_before('Package[etcd]') }
+    end
+
+    context 'When specifying a custom discovery endpoint and token' do
+      let(:params) { {
+          :discovery          => true,
+          :discovery_endpoint => 'http://local-discovery:4001/v2/keys/',
+          :discovery_token    => '123456'
+        } }
+      it {
+        should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_DISCOVER_ENDPOINT="http:\/\/local-discovery:4001\/v2\/keys\/"/)
+        should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_DISCOVERY_TOKEN="123456"/)
+      }
+    end
+    
+    context 'When enabling cluster discovery without a token' do
+      let(:params) { { :discovery => true } }
+      it {
+        should raise_error()
+      }
+    end
+    
+    context 'When enabling verbose logging' do
+      let(:params) { { :verbose => true } }
+      it { should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_LOGGING="v"/) }
+    end
+    
+    context 'When enabling very verbose logging' do
+      let(:params) { { :very_verbose => true } }
+      it { should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_LOGGING="vv"/) }
+    end
+
+    context 'When specifying all of the etcd config params' do
+      let(:params) { {
+          :addr                    => '1.2.3.4:5678',
+          :bind_addr               => '9.9.9.9:9999',
+          :ca_file                 => '/test/ca_file',
+          :cert_file               => '/test/cert_file',
+          :cors                    => [ 'cors1', 'cors2' ],
+          :cpu_profile_file        => '/test/cpu_profile_file',
+          :data_dir                => '/test/data_dir',
+          :key_file                => '/test/key_file',
+          :peers                   => [ 'peer1', 'peer2' ],
+          :peers_file              => '/test/peers_file',
+          :max_result_buffer       => '222',
+          :max_retry_attempts      => '333',
+          :node_name               => 'test_node_name',
+          :user                    => 'etcd_user',
+          :group                   => 'etcd_group',
+          :snapshot                => true,
+          :snapshot_count          => '10000',
+          :verbose                 => true,
+          :very_verbose            => true,
+          :peer_election_timeout   => '400',
+          :peer_heartbeat_interval => '60',
+          :peer_addr               => '1.1.1.1:1111',
+          :peer_bind_addr          => '2.2.2.2:2222',
+          :peer_ca_file            => '/test/peer_ca_file',
+          :peer_cert_File          => '/test/peer_cert_file',
+          :peer_key_file           => '/test/peer_key_file'
+        } }
+      it { should contain_group('etcd_group').with_ensure('present') }
+      it { should contain_user('etcd_user').with_ensure('present').with_gid('etcd_group').that_requires('Group[etcd_group]') }
+      it {
+        # Ensure that the config file is correctly populated
+        should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_USER="etcd_user"/)
+        should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_DISCOVER_ENDPOINT="https:\/\/discovery.etcd.io\/"/)
+        should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_DISCOVERY_TOKEN=""/)
+        should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_PEERS="peer1","peer2"/)
+        should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_NODE_NAME="test_node_name"/)
+        should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_LISTEN="1.2.3.4:5678"/)
+        should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_DATA_DIR="\/test\/data_dir"/)
+        should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_OUT_FILE="\/var\/log\/etcd\/etcd.out"/)
+        should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_LOGGING="vv"/)
+        should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_MAXRESULT=222/)
+        should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_RETRIES=333/)
+        should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_CAFILE="\/test\/ca_file"/)
+        should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_CERT="\/test\/cert_file"/)
+        should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_KEY="\/test\/key_file"/)
+        should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_SNAPSHOT="true"/)
+        should contain_file('/etc/sysconfig/etcd').with_content(/ETCD_SNAPSHOT_COUNT="10000"/)
+        should contain_file('/etc/sysconfig/etcd').with_content(/RAFT_LISTEN="1.1.1.1:1111"/)
+        should contain_file('/etc/sysconfig/etcd').with_content(/RAFT_CAFILE="\/test\/peer_ca_file"/)
+        should contain_file('/etc/sysconfig/etcd').with_content(/RAFT_CERT="\/test\/peer_cert_file"/)
+        should contain_file('/etc/sysconfig/etcd').with_content(/RAFT_KEY="\/test\/peer_key_file"/)
       }
     end
   end

--- a/spec/fixtures/classes/etcd/etcd.conf
+++ b/spec/fixtures/classes/etcd/etcd.conf
@@ -1,0 +1,23 @@
+addr               = "etcd.test.local:4001"
+bind_addr          = "etcd.test.local:4001"
+ca_file            = ""
+cert_file          = ""
+cpu_profile_file   = ""
+data_dir           = "/var/lib/etcd"
+key_file           = ""
+max_result_buffer  = 1024
+max_retry_attempts = 3
+name               = "etcd.test.local"
+snapshot           = true
+snapshot-count     = 10000
+verbose            = false
+very_verbose       = false
+
+[peer]
+addr               = "etcd.test.local:7001"
+bind_addr          = "etcd.test.local:7001"
+ca_file            = ""
+cert_file          = ""
+key_file           = ""
+election_timeout   = 200
+heartbeat_interval = 50

--- a/spec/fixtures/classes/etcd/etcd.sysconfig
+++ b/spec/fixtures/classes/etcd/etcd.sysconfig
@@ -13,65 +13,65 @@
 # limitations under the License.
 
 # Daemon User
-ETCD_USER="<%= @user -%>"
+ETCD_USER="etcd"
 
 # Discovery Endpoint
 #  Leave it as the public URL unless you are running your own.
-ETCD_DISCOVER_ENDPOINT="<%= @discovery_endpoint -%>"
+ETCD_DISCOVER_ENDPOINT="https://discovery.etcd.io/"
 
 # Discovery Token
 #  If you are using the discovery protocol you can grab your cluster token
 #  from https://discovery.etcd.io/new if you are not hosting it yourself.
-ETCD_DISCOVERY_TOKEN="<%= @discovery_token -%>"
+ETCD_DISCOVERY_TOKEN=""
 
 # Peer list
 #  You can specify a list here sepearated by commas, or leave it blank if
 #  you're playing with a single node.
-ETCD_PEERS="<%= @peers.join('","') -%>"
+ETCD_PEERS=""
 
 # This node's name as it represents itself on the cluster.
-ETCD_NODE_NAME="<%= @node_name -%>"
+ETCD_NODE_NAME="etcd.test.local"
 
 # Hostname and port for the etcd server to work on.
-ETCD_LISTEN="<%= @addr -%>"
+ETCD_LISTEN="etcd.test.local:4001"
 
 # Directory to store log and snapshot.
-ETCD_DATA_DIR="<%= @data_dir -%>"
+ETCD_DATA_DIR="/var/lib/etcd"
 
 # File to log stdout/stderr to.
 ETCD_OUT_FILE="/var/log/etcd/etcd.out"
 
 # Set logging vebosity for the file above.
 #   Valid options are "", "v" or "vv"
-ETCD_LOGGING="<% if @very_verbose -%>vv<% elsif @verbose -%>v<% end -%>"
+ETCD_LOGGING=""
 
 # Max size of result buffer.
-ETCD_MAXRESULT=<%= @max_result_buffer %>
+ETCD_MAXRESULT=1024
 
 # Number of retries to attempt while joining a cluster
-ETCD_RETRIES=<%= @max_retry_attempts %>
+ETCD_RETRIES=3
 
 # Set security settings for the etcd server.
 #  Leave blank if you do not plan to use this feature, otherwise add appropriate
 #  paths.
-ETCD_CAFILE="<%= @ca_file -%>"
-ETCD_CERT="<%= @cert_file -%>"
-ETCD_KEY="<%= @key_file -%>"
+ETCD_CAFILE=""
+ETCD_CERT=""
+ETCD_KEY=""
 
 # Toggles snapshotting.
 #  Keep blank or set to true.
-ETCD_SNAPSHOT="<%= @snapshot -%>"
-ETCD_SNAPSHOT_COUNT="<%= @snapshot_count %>"
+ETCD_SNAPSHOT="true"
+ETCD_SNAPSHOT_COUNT="10000"
 
 # Hostname and port for the RAFT server to work on.
-RAFT_LISTEN="<%= @peer_addr -%>"
+RAFT_LISTEN="etcd.test.local:7001"
 
 # Set security settings for the RAFT server.
 #  Leave blank if you do not plan to use this feature, otherwise add appropriate
 #  paths.
-RAFT_CAFILE="<%= @peer_ca_file -%>"
-RAFT_CERT="<%= @peer_cert_File -%>"
-RAFT_KEY="<%= @peer_key_file -%>"
+RAFT_CAFILE=""
+RAFT_CERT=""
+RAFT_KEY=""
 
 # Below we build the opts to pass to the init script.
 

--- a/spec/fixtures/classes/etcd/etcd.upstart
+++ b/spec/fixtures/classes/etcd/etcd.upstart
@@ -1,0 +1,16 @@
+# etcd - distributed configuration daemon
+#
+# Maintained by Puppet. Do not edit by hand. 
+#
+description	"distributed configuration daemon"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+
+# Official way to run as a different user:
+# http://upstart.ubuntu.com/cookbook/#run-a-job-as-a-different-user
+
+exec su -s /bin/sh -c 'exec "$0" "$@"' etcd -- /usr/bin/etcd -config /etc/etcd/etcd.conf >> /var/log/etcd/etcd.out
+

--- a/templates/etcd.conf.erb
+++ b/templates/etcd.conf.erb
@@ -2,12 +2,14 @@ addr               = "<%= @addr -%>"
 bind_addr          = "<%= @bind_addr -%>"
 ca_file            = "<%= @ca_file -%>"
 cert_file          = "<%= @cert_file -%>"
-cors               = ["<%= @cors.join('", "') -%>"]
+<% if @cors and !@cors.empty? -%>
+cors               = ["<%=  @cors.join('", "') -%>"]
+<% end -%>
 cpu_profile_file   = "<%= @cpu_profile_file -%>"
 data_dir           = "<%= @data_dir -%>"
 key_file           = "<%= @key_file -%>"
-<% if @peers -%>
-peers              = ["<%= @peers.join('", "') -%>"]
+<% if @peers and !@peers.empty? -%>
+peers              = ["<%=  @peers.join('", "') -%>"]
 <% end -%>
 <% if @peers_file -%>
 peers_file         = "<%= @peers_file -%>"

--- a/templates/etcd.sysconfig.erb
+++ b/templates/etcd.sysconfig.erb
@@ -43,7 +43,7 @@ ETCD_OUT_FILE="/var/log/etcd/etcd.out"
 
 # Set logging vebosity for the file above.
 #   Valid options are "", "v" or "vv"
-ETCD_LOGGING="<% if @verbose == "true" -%>v<% end -%><% if @very_verbose == "true" -%>vv<% end -%>"
+ETCD_LOGGING="<% if @very_verbose -%>vv<% elsif @verbose -%>v<% end -%>"
 
 # Max size of result buffer.
 ETCD_MAXRESULT=<%= @max_result_buffer -%>


### PR DESCRIPTION
- Added tests of EL support. 
- Test default file content is correct
- Fixed a bug with enabling verbose or very_verbose logging on EL. 
- Fixed a bug with '/etc/etcd/etcd.conf' file ownership on Debian. 
- Added Puppet resource test coverage stats. 
- Switched to using Librarian-Puppet to install module dependencies. 
