### PR TITLE
[#73607174] Add new parameter $etcd::manage_service_file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@
 class etcd (
   $service_ensure          = $etcd::params::etcd_service_ensure,
   $service_enable          = $etcd::params::etcd_service_enable,
+  $manage_service_file     = $etcd::params::etcd_manage_service_file,
   $package_ensure          = $etcd::params::etcd_package_ensure,
   $package_name            = $etcd::params::etcd_package_name,
   $binary_location         = $etcd::params::etcd_binary_location,
@@ -72,6 +73,7 @@ class etcd (
   validate_bool($verbose)
   validate_bool($very_verbose)
   validate_bool($manage_data_dir)
+  validate_bool($manage_service_file)
 
   anchor { 'etcd::begin': } ->
   class { '::etcd::install': } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,7 @@ class etcd::params {
   # Service settings
   $etcd_service_ensure          = 'running'
   $etcd_service_enable          = true
+  $etcd_manage_service_file     = true
 
   # Package settings
   $etcd_package_ensure          = 'installed'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -22,14 +22,16 @@ class etcd::service {
   }
 
   # Create the appropriate service file
-  file { 'etcd-servicefile':
-    ensure  => file,
-    path    => $service_file_location,
-    owner   => $etcd::user,
-    group   => $etcd::group,
-    mode    => $service_file_mode,
-    content => $service_file_contents,
-    notify  => Service['etcd']
+  if $etcd::manage_service_file {
+    file { 'etcd-servicefile':
+      ensure  => file,
+      path    => $service_file_location,
+      owner   => $etcd::user,
+      group   => $etcd::group,
+      mode    => $service_file_mode,
+      content => $service_file_contents,
+      notify  => Service['etcd']
+    }
   }
 
   # Set service status

--- a/spec/classes/etcd_spec.rb
+++ b/spec/classes/etcd_spec.rb
@@ -79,6 +79,13 @@ describe 'etcd', :type => :class do
       it { should contain_service('etcd').with_ensure('stopped').with_enable('false') }
     end
 
+    context 'When asked not to manage the service file' do
+      let(:params) { {
+          :manage_service_file => false
+        } }
+      it { should_not contain_file('etcd-servicefile') }
+    end
+
     context 'When overriding package parameters' do
       let(:params) { {
           :package_ensure => 'absent',
@@ -291,6 +298,13 @@ describe 'etcd', :type => :class do
           :service_ensure => 'stopped',
           :service_enable => false }}
       it { should contain_service('etcd').with_ensure('stopped').with_enable('false') }
+    end
+
+    context 'When asked not to manage the service file' do
+      let(:params) { {
+          :manage_service_file => false
+        } }
+      it { should_not contain_file('etcd-servicefile') }
     end
 
     context 'When overriding package parameters' do


### PR DESCRIPTION
Add a new boolean parameter that determines whether or not this module
will create its own service file.

Useful if your etcd package already provides a service file. Set to
`false` to use the service file provided by your package.
